### PR TITLE
style(frontend): apply vp fmt to ScriptDisplayModal

### DIFF
--- a/frontend/web/components/visualizer/ScriptDisplayModal.tsx
+++ b/frontend/web/components/visualizer/ScriptDisplayModal.tsx
@@ -114,17 +114,18 @@ export const ScriptDisplayModal: FC<ScriptDisplayModalProps> = ({ radioShow }) =
               <div>
                 {loading && <p>読み込み中...</p>}
                 {error && <p className="text-red-500">エラー: {error}</p>}
-                {!loading && !error && (
-                  // <pre> タグで改行や空白もそのまま表示
-                  <pre
-                    className="whitespace-pre-wrap"
-                    style={{
-                      fontFamily: dotGothic16.style.fontFamily,
-                    }}
-                  >
-                    {content}
-                  </pre>
-                )}
+                {!loading &&
+                  !error && (
+                    // <pre> タグで改行や空白もそのまま表示
+                    <pre
+                      className="whitespace-pre-wrap"
+                      style={{
+                        fontFamily: dotGothic16.style.fontFamily,
+                      }}
+                    >
+                      {content}
+                    </pre>
+                  )}
               </div>
             </Card>
 


### PR DESCRIPTION
## What

Apply `vp fmt` to `frontend/web/components/visualizer/ScriptDisplayModal.tsx` so the **Format** workflow's `frontend` job passes.

## Why

The `frontend` check has been **failing on `develop`** (pre-existing, unrelated to any feature work). The `Format` workflow runs:

```sh
vp fmt
git diff --exit-code   # <- failed here
```

The committed JSX in `ScriptDisplayModal.tsx` did not match `vp fmt` (Vite Plus defaults), so `git diff --exit-code` produced a non-zero diff and the job failed. This blocked otherwise-mergeable PRs (e.g. the Dependabot-config PR #106) from reaching all-green.

## The diff

Purely formatting — the formatter breaks the `!loading && !error &&` JSX conditional onto its canonical multi-line layout. No logic change:

```diff
-                {!loading && !error && (
-                  // <pre> タグで改行や空白もそのまま表示
-                  <pre
+                {!loading &&
+                  !error && (
+                    // <pre> タグで改行や空白もそのまま表示
+                    <pre
```

## Verification (local)

- `vp fmt` then `git diff --exit-code` → clean (this is exactly the failing CI step)
- `bun install --frozen-lockfile && bun run test` (`vitest run`) → **3/3 passed**
- `vp check` (type + lint) → **0 errors** (19 pre-existing warnings in unrelated files, not gated by CI)
- Scope is a single file; `backend` is untouched.

No lint/format config was weakened.
