### PR TITLE
ci: mise を撤去しコマンド直接実行へ + SHA pin 化

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -23,14 +23,9 @@ jobs:
       id-token: 'write'
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - name: Use mise
-        run: |
-          curl https://mise.run | sh
-          echo "$HOME/.local/share/mise/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: 'google-github-actions/auth@v3'
+      - uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3
         with:
           # use permissions above
           # see: https://github.com/google-github-actions/auth/blob/main/docs/EXAMPLES.md
@@ -39,7 +34,7 @@ jobs:
           service_account: 'github-actions-on-advena@advena-dev.iam.gserviceaccount.com'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v3'
+        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db' # v3
         with:
           version: '>= 363.0.0'
 
@@ -50,7 +45,7 @@ jobs:
         run: gcloud auth configure-docker us-central1-docker.pkg.dev
 
       - name: Set up Vite Plus
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           run-install: false
           cache: true
@@ -59,11 +54,12 @@ jobs:
         run: vp install
         working-directory: ./frontend/web
 
+      # build/push steps inlined from mise tasks fe:build:* / fe:push:*
       - name: Run build dev
         if: github.ref == 'refs/heads/develop'
         run: |
           set -eo pipefail
-          mise run fe:build:dev
+          docker build --platform linux/amd64 -f Dockerfile.dev -t frontend-advena-dev .
         working-directory: ./frontend/web
         env: # use dotenvx .env.keys for Next.js build with protected github option (allow hironow, and select non-hironow, actions and reusable workflows)
           DOTENV_PRIVATE_KEY_DEV: ${{ secrets.FRONTEND_WEB_DOTENV_PRIVATE_KEY_DEV }}
@@ -72,23 +68,35 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           set -eo pipefail
-          mise run fe:build:prd
+          docker build --platform linux/amd64 -f Dockerfile.prd -t frontend-advena-prd .
         working-directory: ./frontend/web
         env: # use dotenvx .env.keys for Next.js build with protected github option
           DOTENV_PRIVATE_KEY_PRD: ${{ secrets.FRONTEND_WEB_DOTENV_PRIVATE_KEY_PRD }}
-  
+
       - name: Run push dev
         if: github.ref == 'refs/heads/develop'
         run: |
           set -eo pipefail
-          mise run fe:push:dev
+          BRANCH=$(git symbolic-ref --short HEAD)
+          COMMIT=$(git describe --tags --always)
+          TAG="${BRANCH}-${COMMIT}-dev"
+          NAME="us-central1-docker.pkg.dev/advena-dev/advena/frontend-advena:${TAG}"
+          echo "Deploying ${NAME}"
+          docker tag frontend-advena-dev:latest "${NAME}"
+          docker push "${NAME}"
         working-directory: ./frontend/web
-  
+
       - name: Run push prd
         if: github.ref == 'refs/heads/main'
         run: |
           set -eo pipefail
-          mise run fe:push:prd
+          BRANCH=$(git symbolic-ref --short HEAD)
+          COMMIT=$(git describe --tags --always)
+          TAG="${BRANCH}-${COMMIT}-prd"
+          NAME="us-central1-docker.pkg.dev/advena-dev/advena/frontend-advena:${TAG}"
+          echo "Deploying ${NAME}"
+          docker tag frontend-advena-prd:latest "${NAME}"
+          docker push "${NAME}"
         working-directory: ./frontend/web
 
 
@@ -99,14 +107,9 @@ jobs:
       id-token: 'write'
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - name: Use mise
-        run: |
-          curl https://mise.run | sh
-          echo "$HOME/.local/share/mise/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: 'google-github-actions/auth@v3'
+      - uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3
         with:
           # use permissions above
           project_id: 'advena-dev'
@@ -114,7 +117,7 @@ jobs:
           service_account: 'github-actions-on-advena@advena-dev.iam.gserviceaccount.com'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v3'
+        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db' # v3
         with:
           version: '>= 363.0.0'
   
@@ -125,36 +128,37 @@ jobs:
         run: gcloud auth configure-docker us-central1-docker.pkg.dev
 
       - name: Set up Takumi Guard PyPI
-        uses: flatt-security/setup-takumi-guard-pypi@v1
+        uses: flatt-security/setup-takumi-guard-pypi@733047c120b6377fa05fb77f714df8d8cd3a41a9 # v1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: ./backend/genai/uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
 
       - name: Install dependencies
-        run: mise exec -- uv sync --frozen
+        run: uv sync --frozen
         working-directory: ./backend/genai
 
+      # build/push steps inlined from mise tasks be:build:* / be:push:*
       - name: Run build dev
         if: github.ref == 'refs/heads/develop'
         run: |
           set -eo pipefail
-          mise run be:build:dev
-        working-directory: ./backend/genai 
+          docker build --platform linux/amd64 -f Dockerfile.dev -t backend-advena-dev .
+        working-directory: ./backend/genai
         # not use dotenvx .env.keys for build
- 
+
       - name: Run build prd
         if: github.ref == 'refs/heads/main'
         run: |
           set -eo pipefail
-          mise run be:build:prd
+          docker build --platform linux/amd64 -f Dockerfile.prd -t backend-advena-prd .
         working-directory: ./backend/genai
         # not use dotenvx .env.keys for build
 
@@ -162,12 +166,24 @@ jobs:
         if: github.ref == 'refs/heads/develop'
         run: |
           set -eo pipefail
-          mise run be:push:dev
+          BRANCH=$(git symbolic-ref --short HEAD)
+          COMMIT=$(git describe --tags --always)
+          TAG="${BRANCH}-${COMMIT}-dev"
+          NAME="us-central1-docker.pkg.dev/advena-dev/advena/backend-advena:${TAG}"
+          echo "Deploying ${NAME}"
+          docker tag backend-advena-dev:latest "${NAME}"
+          docker push "${NAME}"
         working-directory: ./backend/genai
 
       - name: Run push prd
         if: github.ref == 'refs/heads/main'
         run: |
           set -eo pipefail
-          mise run be:push:prd
+          BRANCH=$(git symbolic-ref --short HEAD)
+          COMMIT=$(git describe --tags --always)
+          TAG="${BRANCH}-${COMMIT}-prd"
+          NAME="us-central1-docker.pkg.dev/advena-dev/advena/backend-advena:${TAG}"
+          echo "Deploying ${NAME}"
+          docker tag backend-advena-prd:latest "${NAME}"
+          docker push "${NAME}"
         working-directory: ./backend/genai

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -19,15 +19,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - name: Use mise
-        run: |
-          curl https://mise.run | sh
-          echo "$HOME/.local/share/mise/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Vite Plus
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           run-install: false
           cache: true
@@ -54,34 +49,31 @@ jobs:
       id-token: 'write'
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - name: Use mise
-        run: |
-          curl https://mise.run | sh
-          echo "$HOME/.local/share/mise/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Takumi Guard PyPI
-        uses: flatt-security/setup-takumi-guard-pypi@v1
+        uses: flatt-security/setup-takumi-guard-pypi@733047c120b6377fa05fb77f714df8d8cd3a41a9 # v1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: ./backend/genai/uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
 
       - name: Install dependencies
-        run: mise exec -- uv sync --frozen
+        run: uv sync --frozen
         working-directory: ./backend/genai
 
+      # inlined from mise task be:format
       - name: Run format
         run: |
-          mise run be:format
+          uv run ruff check --select I --fix
+          uv run ruff format
           git diff --exit-code
         working-directory: ./backend/genai
         env:
@@ -93,15 +85,21 @@ jobs:
         working-directory: ./backend/genai
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install json2ts
         run: bun install -g json-schema-to-typescript
         # below python to typescript gen requires json2ts
 
+      # inlined from mise task be:gen
       - name: Run gen
         run: |
-          mise run be:gen
+          set -eo pipefail
+          ENTITY_DIR=./src/event_sourcing/entity
+          GENERATED_DIR=../../frontend/web/lib/firestore/generated
+          PYTHONPATH=$(pwd) uv run pydantic2ts --module ${ENTITY_DIR}/user.py --output ${GENERATED_DIR}/entity_user.ts
+          PYTHONPATH=$(pwd) uv run pydantic2ts --module ${ENTITY_DIR}/radio_show.py --output ${GENERATED_DIR}/entity_radio_show.ts
+          PYTHONPATH=$(pwd) uv run pydantic2ts --module ${ENTITY_DIR}/user_keyword.py --output ${GENERATED_DIR}/entity_user_keyword.ts --exclude User --exclude UserId
           git diff --exit-code
         working-directory: ./backend/genai
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,24 +20,20 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - name: Use mise
-        run: |
-          curl https://mise.run | sh
-          echo "$HOME/.local/share/mise/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install
         working-directory: ./frontend/web
 
+      # inlined from mise task fe:test
       - name: Run test
         run: |
           set -eo pipefail
-          mise run fe:test
+          bun run test
         working-directory: ./frontend/web
 
   backend:
@@ -47,14 +43,9 @@ jobs:
       id-token: 'write'
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - name: Use mise
-        run: |
-          curl https://mise.run | sh
-          echo "$HOME/.local/share/mise/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: 'google-github-actions/auth@v3'
+      - uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3
         with:
           # use permissions above
           project_id: 'advena-dev'
@@ -62,27 +53,29 @@ jobs:
           service_account: 'github-actions-on-advena@advena-dev.iam.gserviceaccount.com'
 
       - name: Set up Takumi Guard PyPI
-        uses: flatt-security/setup-takumi-guard-pypi@v1
+        uses: flatt-security/setup-takumi-guard-pypi@733047c120b6377fa05fb77f714df8d8cd3a41a9 # v1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: ./backend/genai/uv.lock
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
 
       - name: Install dependencies
-        run: mise exec -- uv sync --frozen
+        run: uv sync --frozen
         working-directory: ./backend/genai
 
+      # inlined from mise task be:test (incl. its GOOGLE_CLOUD_PROJECT env)
       - name: Run test
         run: |
           set -eo pipefail
-          mise run be:test
+          uv run pytest --log-cli-level=INFO
         working-directory: ./backend/genai
         env:
           CI: 'true'
+          GOOGLE_CLOUD_PROJECT: 'test-project'


### PR DESCRIPTION
## 概要

GitHub Actions から mise を撤去し、各ジョブが必要とするツールを素の setup アクション / ランナー標準ツールで直接供給する。あわせて、Actions 設定の組織標準 (`sha_pinning_required`) に合わせて全 action 参照を full-length commit SHA に pin した。

## 変更

- `jdx/mise-action` / `curl https://mise.run` を撤去し、必要なツールを個別にセットアップ
- 全 `uses:` 参照を commit SHA pin 化（`# vX` コメントで元 ref を併記）

## 備考

- `mise.toml` はローカル開発用としてそのまま残す（CI のみ mise 非依存化）
- merge 後、リポの Actions allowlist から `jdx/mise-action@*` を除去する
