### PR TITLE
ci: switch bun to canary (Rust rewrite) in GitHub Actions

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -86,6 +86,11 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          # Rust rewrite is distributed via the canary channel only; canary is a
+          # moving tag, so never reuse a cached executable.
+          bun-version: canary
+          no-cache: true
 
       - name: Install json2ts
         run: bun install -g json-schema-to-typescript

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,11 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          # Rust rewrite is distributed via the canary channel only; canary is a
+          # moving tag, so never reuse a cached executable.
+          bun-version: canary
+          no-cache: true
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Why

Bun の Rust rewrite (oven-sh/bun#30412, 2026-05-14 に main へマージ) は **canary チャネルのみ**で配布されている (stable は Zig 版のまま)。CI を Rust 版で回して早期に互換性を検証するため、bun を canary に切り替える。

## What

- bun のインストールを `canary` 指定に変更
  - setup-bun: `bun-version: canary` + `no-cache: true` (canary は moving tag のため、実行ファイルキャッシュが stale 固定するのを防ぐ)
  - curl install: `bash -s "canary"` (install script は引数を GitHub release tag として解決する。`releases/download/canary/` の asset 実在は確認済み)
- 他リポで適用済みの house style と同一パターン

## Risk / Out of scope

- bun canary は stable 製 `bun.lock` を `--frozen-lockfile` で拒否することがある既知問題あり。本 PR の CI が赤くなった場合は lockfile をクリーン環境で canary 再生成して追従する。
- Dockerfile の `oven/bun:1` (stable イメージ) は本 PR の対象外 (移行方針が別途決まり次第)。
