### PR TITLE
fix: Next 16 で廃止された eslint キーを next.config.ts から除去

### DIFF
--- a/frontend/web/next.config.ts
+++ b/frontend/web/next.config.ts
@@ -2,9 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## 概要

develop の `build_and_push` (frontend job) が **2026-06-10 の run から 3 連続 failure** になっている既存バグの修正。frontend のデプロイ画像がビルド不能な状態だった。

## 根本原因

Next.js 16 (現 16.2.9) は `next lint` を廃止し、`NextConfig` 型から `eslint` キーを削除した。`next build` の TypeScript チェックが `next.config.ts:5` で死ぬ:

```
Type error: Object literal may only specify known properties, and 'eslint' does not exist in type 'NextConfig'.
```

CI 証跡: [run 27384898511](https://github.com/hironow/advena/actions/runs/27384898511) (frontend job failure、backend は success)。直近の成功は 6/10 09:28 の run で、それ以降の develop push は全て同エラー。

## 変更

`frontend/web/next.config.ts` から `eslint.ignoreDuringBuilds` ブロックを除去 (3 行削除のみ)。Next 16 はビルド中に ESLint を実行しないため、**挙動は変わらない** — 型エラーだけが消える。

## 検証

ローカルで `docker build -f Dockerfile.dev` / `Dockerfile.prd` ともにフル完走を確認 (next build → standalone 出力まで)。

## 備考

- `images.domains` deprecated / middleware→proxy の警告は別件 (warning のみでビルドは通る)
- 同時に出している Dockerfile の bun canary 化 PR とは独立。本 PR がマージされると develop の build_and_push が緑に戻る
