### PR TITLE
build: web Dockerfile の bun を canary (Rust rewrite) へ切替

### DIFF
--- a/frontend/web/Dockerfile.dev
+++ b/frontend/web/Dockerfile.dev
@@ -7,7 +7,11 @@ FROM node:lts-alpine AS base
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN npm install -g bun && bun install --frozen-lockfile
+# bun canary = Rust rewrite line. npm's bun@canary dist-tag is stale
+# (pre-rewrite), so copy the binary from the official image instead —
+# the -alpine (musl) variant is required on an alpine base.
+COPY --from=oven/bun:canary-alpine /usr/local/bin/bun /usr/local/bin/bun
+RUN bun install --frozen-lockfile
 
 # Stage 2: Build the application
 FROM base AS builder
@@ -16,7 +20,8 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 # dotenvx other env file to avoid conflicts
 RUN rm -f .env.prd
-RUN npm install -g bun && bun run build:dev
+COPY --from=oven/bun:canary-alpine /usr/local/bin/bun /usr/local/bin/bun
+RUN bun run build:dev
 
 # Stage 3: Production server
 FROM base AS runner

--- a/frontend/web/Dockerfile.prd
+++ b/frontend/web/Dockerfile.prd
@@ -7,7 +7,11 @@ FROM node:lts-alpine AS base
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN npm install -g bun && bun install --frozen-lockfile
+# bun canary = Rust rewrite line. npm's bun@canary dist-tag is stale
+# (pre-rewrite), so copy the binary from the official image instead —
+# the -alpine (musl) variant is required on an alpine base.
+COPY --from=oven/bun:canary-alpine /usr/local/bin/bun /usr/local/bin/bun
+RUN bun install --frozen-lockfile
 
 # Stage 2: Build the application
 FROM base AS builder
@@ -16,7 +20,8 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 # dotenvx other env file to avoid conflicts
 RUN rm -f .env.dev
-RUN npm install -g bun && bun run build:prd
+COPY --from=oven/bun:canary-alpine /usr/local/bin/bun /usr/local/bin/bun
+RUN bun run build:prd
 
 # Stage 3: Production server
 FROM base AS runner


### PR DESCRIPTION
## 概要

bun canary (Rust rewrite) 横展開の Docker surface 編。CI (GitHub Actions) は #112 で canary 化済みだが、`frontend/web/Dockerfile.dev` / `Dockerfile.prd` は stable (Zig 版) のままだったので揃える。

## 変更

両 Dockerfile (deps / builder ステージ計 4 箇所):

```dockerfile
# before
RUN npm install -g bun && bun install --frozen-lockfile
# after
COPY --from=oven/bun:canary-alpine /usr/local/bin/bun /usr/local/bin/bun
RUN bun install --frozen-lockfile
```

- npm レジストリの `bun@canary` dist-tag は **rewrite 前 (1.3.13-canary.20260425.1, 4/25) で更新停止**しており使えないため、公式イメージからのバイナリ COPY に置換
- ベースが `node:lts-alpine` なので **musl 版 `oven/bun:canary-alpine`** を使用 (glibc 版だと動かない)

## 検証 (ローカル実機)

- `oven/bun:canary-alpine` = `1.4.0-canary.1+f8723b190` (Rust 版) を確認
- 修正 PR (next.config.ts) を当てた状態で `docker build -f Dockerfile.dev` / `Dockerfile.prd` とも**フル完走** (canary bun で `bun install --frozen-lockfile` + `next build` standalone 出力まで)
- 対照実験: 変更前の Dockerfile も同条件でビルドし、失敗箇所が next.config.ts の型エラー (既存バグ、別 PR で修正) のみであることを確認 — canary 起因の差分なし

## 備考

- 本 PR の CI (test/format) は Dockerfile をビルドしない (build_and_push の pull_request トリガーは main 向けのみ)。Docker ビルドの実証は上記ローカル完走が根拠
- next.config.ts 修正 PR がマージされるまでは、merge 後の develop push の build_and_push (frontend) は既存の型エラーで赤のまま (本 PR とは独立の既存事象)
