### PR TITLE
ci(format): exclude bun.lock from the frontend format-check diff

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -34,12 +34,16 @@ jobs:
       - name: Run format check
         run: |
           vp fmt
-          git diff --exit-code
+          # Check only source formatting, not bun.lock: `vp install` above
+          # rewrites bun.lock (canary bun / vp is a moving target), which is a
+          # dependency-resolution artifact, not a formatting change. Excluding
+          # it stops every Dependabot bump from failing this format gate.
+          git diff --exit-code -- . ':!bun.lock'
         working-directory: ./frontend/web
 
       - name: Show formatting diff on failure
         if: failure()
-        run: git diff
+        run: git diff -- . ':!bun.lock'
         working-directory: ./frontend/web
 
   backend:


### PR DESCRIPTION
The frontend format job runs `vp install` (rewrites bun.lock under canary bun / vp — moving targets) then `git diff --exit-code`, so the diff picks up the churned lockfile and **fails the format gate on every Dependabot PR** (#133/#134/#135 all failed `frontend` though formatting was clean). bun.lock is a dependency-resolution artifact, not formatting — exclude it (`':!bun.lock'`) so the gate checks only source.

After this merges, #133/#134/#135 should pass `frontend` on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)