### PR TITLE
ci(format): exclude bun.lock from the frontend format-check diff

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -34,12 +34,16 @@ jobs:
       - name: Run format check
         run: |
           vp fmt
-          git diff --exit-code
+          # Check only source formatting, not bun.lock: `vp install` above
+          # rewrites bun.lock (canary bun / vp is a moving target), which is a
+          # dependency-resolution artifact, not a formatting change. Excluding
+          # it stops every Dependabot bump from failing this format gate.
+          git diff --exit-code -- . ':!bun.lock'
         working-directory: ./frontend/web
 
       - name: Show formatting diff on failure
         if: failure()
-        run: git diff
+        run: git diff -- . ':!bun.lock'
         working-directory: ./frontend/web
 
   backend:


### PR DESCRIPTION
`vp install` rewrites `frontend/web/bun.lock` under canary bun/vp (a moving target). The frontend format job's `git diff --exit-code` then flags that lockfile churn and fails **every** Dependabot bump, even when source formatting is clean.

Fix: exclude `bun.lock` from the format-check diff (and the failure-diff step) — it's a dependency-resolution artifact, not a formatting change.

This is the same fix already merged to `main` (#137), applied to `develop` — the default branch that actually gates Dependabot PRs #133/#134/#135. Once merged, those three (rebased) will pass the `frontend` check.