### PR TITLE
fix(frontend): hold typescript at ^6 to unbreak the develop build

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,6 +28,14 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # Hold the TypeScript major (6->7). TS7 is the Go-native rewrite: it drops
+    # the classic 'main: ./lib/typescript.js' entry point, so next 16 thinks
+    # typescript is missing and dies trying to auto-install it during the
+    # Docker build. Take the rest of the weekly npm group. Revisit once next
+    # supports TS7 (crediflow holds the same major for its own reason).
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm:
         patterns: ["*"]

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -70,7 +70,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.12",
     "tsx": "^4.20.4",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.0"
   },
   "packageManager": "bun@1.3.12"


### PR DESCRIPTION
## 症状

develop HEAD の `frontend` ジョブが継続的に fail。Docker build の `bun run build:dev` で:

```
Installing devDependencies (yarn):
- typescript
error This project's package.json defines "packageManager": "yarn@bun@1.3.12". ...
Failed to install required TypeScript dependencies
```

## 真因

**TypeScript 7 (Go ネイティブ移植) がパッケージ形態を変えた**ため、next 16 が TS を検出できない。

| | 6.0.3 | 7.0.2 |
|---|---|---|
| `main` | `./lib/typescript.js` | **なし** |
| `exports["."]` | - | `./lib/version.cjs` (バージョン番号のみ) |
| コンパイラAPI | 上記 main | `typescript/unstable/*` へ移動 |
| コンパイラ本体 | 同梱 | プラットフォーム別 optionalDependencies |

next 16.2.7 は従来のエントリポイントを探すので TS7 では「typescript が無い」と判断し、yarn で自動インストールを試みて死ぬ。

時系列も一致する:

```
56f5ec17 (TS bump 前)              -> success
8ddfe9e5 typescript 6.0.3 -> 7.0.2
2e192fb1 (HEAD)                    -> failure
```

補足: ログの `"packageManager": "yarn@bun@1.3.12"` は **yarn 1.x が自分のメッセージに `yarn@` を前置しているだけ**で、フィールド自体は `bun@1.3.12` で正しい。ここは誤読しやすいので記録しておく。

## 対応

設定では回避できず **next 側の TS7 対応待ち**なので、

1. `frontend/web/package.json`: `typescript` を `^6.0.3` へ差し戻し(`bun.lock` は元々 6.0.3 解決なので**変更なし**、`bun install --frozen-lockfile` 通過を確認済み)
2. `.github/dependabot.yaml`: npm エコシステムに `typescript` の **semver-major ignore** を追加。minor/patch は従来どおり流れる

同一 org の crediflow が既に同じメジャーを保留しており、様式を揃えた。next が TS7 に対応したら両方まとめて解除する。