### PR TITLE
ci(dependabot): switch npm ecosystem to bun

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,7 +18,10 @@ updates:
       github-actions:
         patterns: ["*"]
 
-  - package-ecosystem: "npm"
+  # bun ecosystem: regenerates bun.lock alongside package.json. The old "npm"
+  # ecosystem only rewrote package.json and left bun.lock stale, desyncing the
+  # lockfile on every bump (had to be hand-synced on PR #146).
+  - package-ecosystem: "bun"
     directory: "/frontend/web"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The `npm` ecosystem rewrites `package.json` but **not `bun.lock`**, so every version bump desynced the lockfile and needed a hand-sync commit before merge. The `bun` ecosystem (GA 2025-02) regenerates `bun.lock` alongside `package.json`. Same switch m4k3-co/m4k3 made in #212 after its closed PR #132 hit the identical desync.