### PR TITLE
build(frontend): drop dangling bun.lock entry that canary bun rejects

### DIFF
--- a/frontend/web/bun.lock
+++ b/frontend/web/bun.lock
@@ -420,8 +420,6 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.12", "", { "os": "win32", "cpu": "x64" }, "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw=="],
 
-    "@noble/hashes": ["@noble/hashes@1.8.0", "https://npm.flatt.tech/@noble/hashes/-/hashes-1.8.0.tgz", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "@nodable/entities": ["@nodable/entities@1.1.0", "https://npm.flatt.tech/@nodable/entities/-/entities-1.1.0.tgz", {}, "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],


### PR DESCRIPTION
## 症状

#154(npm group) マージ後、develop の **Build and Push** の frontend ジョブが Docker image build で落ちる：

```
#14 RUN bun install --frozen-lockfile
error: lockfile had changes, but lockfile is frozen
```

**Test workflow は緑のまま**なので見落としやすい — 同名の `frontend` ジョブがあるが Test は本番 image を build しない。Build and Push は build し、`Dockerfile.dev` が commit 済みの bun.lock を COPY して `oven/bun:canary-alpine`(bun 1.4.0-canary)で `--frozen-lockfile` する。その canary が lock を拒否していた。

## 真因

Dependabot が生成した lock に残っていた **`@noble/hashes@1.8.0` の重複(dangling)エントリ**。canary bun は `--frozen` 下でこれを drift と見なして中断する。安定版 bun は許容していたため、すり抜けていた。

## 修正

`Dockerfile.dev` が使う **`oven/bun:canary-alpine` イメージそのもの**で bun.lock を再生成。差分は重複エントリの削除**のみ(2行)**。

## 検証

`bun install --frozen-lockfile` が以下**両方**で clean な no-op になることを確認：

| 環境 | 結果 |
|---|---|
| canary 1.4.0（Dockerイメージ内） | Checked 914 installs, no changes |
| 安定版 1.3.14 | Checked 906 installs, no changes |

Build and Push も Test も回帰しない。依存バージョンの変更なし。